### PR TITLE
Fix: Configure AWS Credentials using environment secrets

### DIFF
--- a/.github/workflows/cft-deploy.yml
+++ b/.github/workflows/cft-deploy.yml
@@ -80,12 +80,12 @@ jobs:
 
     - name: Set DEPLOYMENT_ENV and DEPLOYMENT_ROLE_ARN and S3_BUCKET
       env: 
-        DEV_DEPLOYMENT_ROLE: ${{ vars.DEPLOYMENT_ROLE_DEV }}
-        QA_DEPLOYMENT_ROLE: ${{ vars.DEPLOYMENT_ROLE_QA }}
-        PROD_DEPLOYMENT_ROLE: ${{ vars.DEPLOYMENT_ROLE_PROD }}
-        DEV_S3_BUCKET: ${{ vars.S3_BUCKET_DEV }}
-        QA_S3_BUCKET: ${{ vars.S3_BUCKET_QA }}
-        PROD_S3_BUCKET: ${{ vars.S3_BUCKET_PROD }}
+        DEV_DEPLOYMENT_ROLE: ${{ secrets.DEPLOYMENT_ROLE_DEV }}
+        QA_DEPLOYMENT_ROLE: ${{ secrets.DEPLOYMENT_ROLE_QA }}
+        PROD_DEPLOYMENT_ROLE: ${{ secrets.DEPLOYMENT_ROLE_PROD }}
+        DEV_S3_BUCKET: ${{ secrets.S3_BUCKET_DEV }}
+        QA_S3_BUCKET: ${{ secrets.S3_BUCKET_QA }}
+        PROD_S3_BUCKET: ${{ secrets.S3_BUCKET_PROD }}
       run: |
          if [[ $BRANCH == 'master' || $BRANCH == 'main' ]]; then 
           echo "DEPLOYMENT_ENV=prod" >> "$GITHUB_ENV" 
@@ -114,7 +114,7 @@ jobs:
       uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: ${{env.DEPLOYMENT_ROLE_ARN}}
-        aws-region: ${{vars.AWS_REGION}}
+        aws-region: ${{secrets.AWS_REGION}}
 
     - name: Setup AWS SAM
       uses: aws-actions/setup-sam@v2


### PR DESCRIPTION
This PR addresses the workflow failure by modifying the `cft-deploy.yml` to use GitHub Environment Secrets instead of GitHub Variables for sensitive AWS configuration values like `AWS_REGION`, `DEPLOYMENT_ROLE_ARN`, and `S3_BUCKET`.

**Root Cause:** The previous configuration relied on GitHub Variables (`vars.AWS_REGION`, etc.) which were not defined in the repository or environment settings. This resulted in empty values being passed to the `aws-actions/configure-aws-credentials` action, causing it to fail with the error 'Input required and not supplied: aws-region'.

**Fix:**
1.  Updated `cft-deploy.yml` to reference `secrets.AWS_REGION`, `secrets.DEPLOYMENT_ROLE_DEV/QA/PROD`, and `secrets.S3_BUCKET_DEV/QA/PROD`.
2.  **Action Required:** After merging this PR, the following secrets MUST be created in the GitHub repository's 'Environments' settings (for `dev`, `qa`, and `prd` environments respectively):
    *   `AWS_REGION` (e.g., `us-east-1`)
    *   `DEPLOYMENT_ROLE_DEV` (ARN for dev IAM role)
    *   `DEPLOYMENT_ROLE_QA` (ARN for qa IAM role)
    *   `DEPLOYMENT_ROLE_PROD` (ARN for prod IAM role)
    *   `S3_BUCKET_DEV` (S3 bucket name for dev)
    *   `S3_BUCKET_QA` (S3 bucket name for qa)
    *   `S3_BUCKET_PROD` (S3 bucket name for prod)

This change ensures that sensitive credentials are handled securely and are properly configured for each deployment environment.

## Summary by Sourcery

Update the CloudFormation deployment workflow to source AWS configuration from environment secrets instead of variables for reliable credentials setup.

Bug Fixes:
- Fix failing cft-deploy workflow by ensuring aws-actions/configure-aws-credentials receives a non-empty AWS region from environment secrets.

CI:
- Change cft-deploy GitHub Actions workflow to use environment-level secrets for deployment roles, S3 buckets, and AWS region.